### PR TITLE
Added nomination searching.

### DIFF
--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -25,7 +25,7 @@
  * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
  * by the Valve Corporation.  You must obey the GNU General Public License in
  * all respects for all other code used.  Additionally, AlliedModders LLC grants
- * this exception to all derivative works.  AlliedModders LLC defines further
+ * this exception to all derivative works.	AlliedModders LLC defines further
  * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
  * or <http://www.sourcemod.net/license.php>.
  *
@@ -88,8 +88,8 @@ public OnPluginStart()
 	
 	RegConsoleCmd("sm_nominate", Command_Nominate);
 
-    RegConsoleCmd("sm_nomgrep", Command_Nomgrep);
-    RegConsoleCmd("sm_nomsearch", Command_Nomgrep);
+	RegConsoleCmd("sm_nomgrep", Command_Nomgrep);
+	RegConsoleCmd("sm_nomsearch", Command_Nomgrep);
 	
 	RegAdminCmd("sm_nominate_addmap", Command_Addmap, ADMFLAG_CHANGEMAP, "sm_nominate_addmap <mapname> - Forces a map to be on the next mapvote.");
 	
@@ -288,52 +288,52 @@ public Action:Command_Nominate(client, args)
 
 public Action:Command_Nomgrep(client, args)
 {
-    if (!client || !IsNominateAllowed(client))
-    {
-        return Plugin_Handled;
-    }
+	if (!client || !IsNominateAllowed(client))
+	{
+		return Plugin_Handled;
+	}
 
-    if (args == 0)
-    {
-        ReplyToCommand(client, "[NE] Usage: sm_nomgrep <search key>");
-    }
+	if (args == 0)
+	{
+		ReplyToCommand(client, "[NE] Usage: sm_nomgrep <search key>");
+	}
 
-    decl String:search[MAP_NAME_LENGTH];
-    GetCmdArg(1, search, sizeof(search));
+	decl String:search[MAP_NAME_LENGTH];
+	GetCmdArg(1, search, sizeof(search));
 
-    BuildSearchMenu(client, search);
+	BuildSearchMenu(client, search);
 
-    return Plugin_Continue;
+	return Plugin_Continue;
 }
 
 //Build a menu of maps in the maplist that also contain the search key.
 BuildSearchMenu(client, String:search[MAP_NAME_LENGTH])
 {
 
-    new Handle:tmpMenu=CreateMenu(Handler_MapSelectMenu, MENU_ACTIONS_DEFAULT|MenuAction_DrawItem|MenuAction_DisplayItem);
-    new String:tmpMap[MAP_NAME_LENGTH];
-    new tmpStyle;
+	new Handle:tmpMenu=CreateMenu(Handler_MapSelectMenu, MENU_ACTIONS_DEFAULT|MenuAction_DrawItem|MenuAction_DisplayItem);
+	new String:tmpMap[MAP_NAME_LENGTH];
+	new tmpStyle;
 
-    //For each map in the normal map menu
-    for (new i = 0; i < GetMenuItemCount(g_MapMenu); i++)
-    {
-        GetMenuItem(g_MapMenu, i, tmpMap, MAP_NAME_LENGTH);
+	//For each map in the normal map menu
+	for (new i = 0; i < GetMenuItemCount(g_MapMenu); i++)
+	{
+		GetMenuItem(g_MapMenu, i, tmpMap, MAP_NAME_LENGTH);
 
-        if(StrContains(tmpMap, search, false) >= 0)
-        {
-            AddMenuItem(tmpMenu, tmpMap, tmpMap);
-        }
-    }
+		if(StrContains(tmpMap, search, false) >= 0)
+		{
+			AddMenuItem(tmpMenu, tmpMap, tmpMap);
+		}
+	}
 
-    if(GetMenuItemCount(tmpMenu) <= 0)
-    {
+	if(GetMenuItemCount(tmpMenu) <= 0)
+	{
 		ReplyToCommand(client, "%t", "Map was not found", search);
-    }
-    else
-    {
-        SetMenuTitle(tmpMenu, "%t", "Nominate Title", client);
-        DisplayMenu(tmpMenu, client, MENU_TIME_FOREVER);
-    }
+	}
+	else
+	{
+		SetMenuTitle(tmpMenu, "%t", "Nominate Title", client);
+		DisplayMenu(tmpMenu, client, MENU_TIME_FOREVER);
+	}
 	
 	return;
 }

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -87,6 +87,9 @@ public OnPluginStart()
 	RegConsoleCmd("say_team", Command_Say);
 	
 	RegConsoleCmd("sm_nominate", Command_Nominate);
+
+    RegConsoleCmd("sm_nomgrep", Command_Nomgrep);
+    RegConsoleCmd("sm_nomsearch", Command_Nomgrep);
 	
 	RegAdminCmd("sm_nominate_addmap", Command_Addmap, ADMFLAG_CHANGEMAP, "sm_nominate_addmap <mapname> - Forces a map to be on the next mapvote.");
 	
@@ -282,6 +285,39 @@ public Action:Command_Nominate(client, args)
 	
 	return Plugin_Continue;
 }
+
+public Action:Command_Nomgrep(client, args)
+{
+    if (!client || !IsNominateAllowed(client))
+    {
+        return Plugin_Handled;
+    }
+
+    if (args == 0)
+    {
+        ReplyToCommand(client, "[NE] Usage: sm_nomgrep <search key>");
+    }
+
+    decl String:search[MAP_NAME_LENGTH];
+    GetCmdArg(1, search, sizeof(search));
+
+    return Plugin_Continue;
+}
+
+BuildSearchMenu(client, String:search[MAP_NAME_LENGTH])
+{
+
+    new Handle:tmpMenu=CreateMenu(Handler_MapSelectMenu, MENU_ACTIONS_DEFAULT|MenuAction_DrawItem|MenuAction_DisplayItem);
+    new String:tmpMap[MAP_NAME_LENGTH];
+    new tmpStyle;
+
+    //For each map in the normal map menu
+    for (new i = 0; i < GetMenuItemCount(g_MapMenu); i++)
+    {
+        GetMenuItem(g_MapMenu, i, tmpMap, MAP_NAME_LENGTH);
+    }
+}
+
 
 AttemptNominate(client)
 {

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -327,7 +327,7 @@ BuildSearchMenu(client, String:search[MAP_NAME_LENGTH])
 
     if(GetMenuItemCount(tmpMenu) <= 0)
     {
-		ReplyToCommand(client, "%t", "Map was not found", mapname);
+		ReplyToCommand(client, "%t", "Map was not found", search);
     }
     else
     {

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -304,6 +304,7 @@ public Action:Command_Nomgrep(client, args)
     return Plugin_Continue;
 }
 
+//Build a menu of maps in the maplist that also contain the search key.
 BuildSearchMenu(client, String:search[MAP_NAME_LENGTH])
 {
 
@@ -315,7 +316,24 @@ BuildSearchMenu(client, String:search[MAP_NAME_LENGTH])
     for (new i = 0; i < GetMenuItemCount(g_MapMenu); i++)
     {
         GetMenuItem(g_MapMenu, i, tmpMap, MAP_NAME_LENGTH);
+
+        if(StrContains(tmpMap, search, false) >= 0)
+        {
+            AddMenuItem(tmpMenu, tmpMap, tmpMap);
+        }
     }
+
+    if(GetMenuItemCount(tmpMenu) <= 0)
+    {
+		ReplyToCommand(client, "%t", "Map was not found", mapname);
+    }
+    else
+    {
+        SetMenuTitle(tmpMenu, "%t", "Nominate Title", client);
+        DisplayMenu(tmpMenu, client, MENU_TIME_FOREVER);
+    }
+	
+	return;
 }
 
 

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -301,6 +301,8 @@ public Action:Command_Nomgrep(client, args)
     decl String:search[MAP_NAME_LENGTH];
     GetCmdArg(1, search, sizeof(search));
 
+    BuildSearchMenu(client, search);
+
     return Plugin_Continue;
 }
 


### PR DESCRIPTION
Integrated logic from [my nomgrep plugin](https://github.com/CrimsonTautology/nomgrep).  Allows players to filter the nomination list by sub string.  For example typing `!nomsearch koth_` would generate a list of all koth maps on the server.  Or if you know you want to play koth_ashville, but are unsure of what version is on the server you can type `!nomsearch ash` to filter the menu by all maps containing "ash".  This is great for servers that have huge map lists and you don't want to press 9 a bunch of times to get to the map you want.
