### PR TITLE
Prevent clients from spamming global chat using sm_nominate

### DIFF
--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -275,7 +275,7 @@ public Action:Command_Nominate(client, args)
 	
 	decl String:name[MAX_NAME_LENGTH];
 	GetClientName(client, name, sizeof(name));
-	PrintToChatAll("[NE] %t", "Map Nominated", name, mapname);
+	CReplyToCommand(client, "[NE] %t", "Map Nominated", name, mapname);
 	LogMessage("%s nominated %s", name, mapname);
 
 	return Plugin_Continue;


### PR DESCRIPTION
Using the nominate command it is possible to spam global chat by alternating between two maps e.g.
bind mwheeldown "sm_nominate de_dust2;sm_nominate de_mirage;"
By replying to successful nominations instead of putting in global this issue is prevented as clients can only spam themselves.